### PR TITLE
Fix process errors

### DIFF
--- a/platform/ABModel.js
+++ b/platform/ABModel.js
@@ -2020,10 +2020,12 @@ module.exports = class ABModel extends ABModelCore {
 
          let whereString = "";
          try {
-            whereString = formulaFieldQuery.toString(); // select `DB_NAME`.`AB_TABLE_NAME`.* from `DB_NAME`.`AB_TABLE_NAME` where (`DB_NAME`.`AB_TABLE_NAME`.`COLUMN` LIKE '%VALUE%')
-
+            whereString = formulaFieldQuery.toKnexQuery().toString(); // select `DB_NAME`.`AB_TABLE_NAME`.* from `DB_NAME`.`AB_TABLE_NAME` where (`DB_NAME`.`AB_TABLE_NAME`.`COLUMN` LIKE '%VALUE%')
             // get only where clause
-            let wherePosition = whereString.indexOf("where");
+            const wherePosition = whereString.indexOf("where");
+            if (wherePosition == -1) {
+               throw new Error("No 'where' found in query");
+            }
             whereString = whereString.substring(
                wherePosition + 5,
                whereString.length

--- a/platform/ABModel.js
+++ b/platform/ABModel.js
@@ -2031,6 +2031,17 @@ module.exports = class ABModel extends ABModelCore {
                whereString.length
             ); // It should be (`DB_NAME`.`AB_TABLE_NAME`.`COLUMN` LIKE '%VALUE%')
 
+            // Replace definition id with col name
+            const uuid = new RegExp(
+               /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/g
+            );
+            // {Regex} should match uuids (from https://ihateregex.io/expr/uuid/)
+
+            whereString = whereString.replace(uuid, (match) => {
+               const { columnName } = this.AB.definitionByID(match);
+               return columnName;
+            });
+
             if (whereString) whereClause = ` AND ${whereString}`;
          } catch (e) {
             req.notify.developer(e, { field: formulaField });

--- a/platform/process/tasks/ABProcessElement.js
+++ b/platform/process/tasks/ABProcessElement.js
@@ -124,8 +124,14 @@ module.exports = class ABProcessTask extends ABProcessElementCore {
     */
    onError(instance, error) {
       super.onError(instance, error);
-
+      const trimedInstance = {
+         uuid: instance.uuid,
+         processID: instance.processID,
+         status: instance.status,
+         statriggeredBy: instance.triggeredBy,
+         log: instance.log,
+      };
       var text = `ProcessTask Error: ${this.key} : ${error.toString()}`;
-      console.error(text, { instance: instance, error: error });
+      console.error(text, { instance: trimedInstance, error: error });
    }
 };

--- a/platform/process/tasks/ABProcessTaskServiceCalculate.js
+++ b/platform/process/tasks/ABProcessTaskServiceCalculate.js
@@ -44,8 +44,10 @@ module.exports = class CalculateTask extends CalculateTaskCore {
             item.key,
          ]);
 
+         // Escape brackets (,) in label so that the regex works
+         const label = item.label.replace(/\(/, "\\(").replace(/\)/, "\\)");
          formula = formula.replace(
-            new RegExp(`{${item.label}}`, "g"),
+            new RegExp(`{${label}}`, "g"),
             processedData == null ? 0 : processedData
          );
       });

--- a/platform/process/tasks/ABProcessTaskServiceInsertRecord.js
+++ b/platform/process/tasks/ABProcessTaskServiceInsertRecord.js
@@ -1,5 +1,4 @@
 const InsertRecordTaskCore = require("../../../core/process/tasks/ABProcessTaskServiceInsertRecordCore.js");
-const ABProcessTaskServiceQuery = require("./ABProcessTaskServiceQuery.js");
 
 module.exports = class InsertRecord extends InsertRecordTaskCore {
    ////

--- a/platform/process/tasks/ABProcessTaskServiceInsertRecord.js
+++ b/platform/process/tasks/ABProcessTaskServiceInsertRecord.js
@@ -175,10 +175,7 @@ module.exports = class InsertRecord extends InsertRecordTaskCore {
 
       let result = null;
 
-      if (
-         prevElem instanceof InsertRecord ||
-         prevElem instanceof ABProcessTaskServiceQuery
-      ) {
+      if (prevElem instanceof InsertRecord) {
          result = prevElem.processData(instance);
       }
 


### PR DESCRIPTION
Includes commits from #15
Fixes two issues:
- The Insert Task option `use parameter of previous task` was depreciated for query tasks in v1, but v2 was still trying to process data, which gave an error
- Calculate task uses regex based on field labels but did not escape brackets in the label.