### PR TITLE
Fix out-of-memory crash

### DIFF
--- a/platform/ABObject.js
+++ b/platform/ABObject.js
@@ -284,7 +284,10 @@ module.exports = class ABClassObject extends ABObjectCore {
          req.retry(() =>
             SiteUser.find({
                where: { username: condDefaults.username, isActive: 1 },
-               populate: true,
+               populate: [
+                  "SITE_ROLE",
+                  "SITE_SCOPE"
+               ],
             })
          ).then((list) => {
             var user = list[0];


### PR DESCRIPTION
This change fixes the "FATAL ERROR: Javascript heap out of memory" that has been crashing `ab_service_appbuilder` on staging2.

The crash happens consistently for the `admin` user, within one minute after loading the site. Staging2 has a lot of data, so it seems like the `"populate": true` option leads to basically the entire DB being fetched just to check the user's roles and scopes.

I think in general, `"populate": true` should not be used unless care has been taken to limit the amount of data it will fetch.