### PR TITLE
[fix] reuse Knex connection pools when ABFactories are recreated

### DIFF
--- a/ABBootstrap.js
+++ b/ABBootstrap.js
@@ -41,7 +41,7 @@ var Listener = null;
 function staleHandler(req) {
    var tenantID = req.tenantID();
    Factories[tenantID]?.emit("bootstrap.stale.reset");
-   KnexPool[tenantID]=Factories[tenantID].Knex.connection();
+   KnexPool[tenantID] = Factories[tenantID].Knex.connection();
    delete Factories[tenantID];
    req.log(`:: Definitions reset for tenant[${tenantID}]`);
 }
@@ -53,15 +53,14 @@ var PendingFactory = {
 // A lookup of Pending Factory builds.  This prevents the SAME factory from
 // being built at the same time.
 
-
 var KnexPool = {
    /* tenantID : AB.Knex.connection() */
-}
+};
 // {hash}
 // When definitions are updated, we destroy the existing ABFactory and create
 // a new one.  However each new ABFactory will create a NEW KNEX DB POOL and
 // eventually we use up all our DB Connections ( error: ER_CON_COUNT_ERROR).
-// The Knex connection won't change due to the Definition updates, so let's 
+// The Knex connection won't change due to the Definition updates, so let's
 // cache the KnexPools here and reuse them.
 
 module.exports = {
@@ -118,7 +117,8 @@ module.exports = {
                                  Factories[tenantID]?.emit(
                                     "bootstrap.stale.reset"
                                  );
-                                 KnexPool[tenantID]=Factories[tenantID].Knex.connection();
+                                 KnexPool[tenantID] =
+                                    Factories[tenantID].Knex.connection();
                                  delete Factories[tenantID];
                               });
                            });

--- a/ABFactory.js
+++ b/ABFactory.js
@@ -34,7 +34,7 @@ function stringifyErrors(param) {
 }
 
 class ABFactory extends ABFactoryCore {
-   constructor(definitions, DefinitionManager, req) {
+   constructor(definitions, DefinitionManager, req, knexConnection = null) {
       /**
        * @param {hash} definitions
        *        { ABDefinition.id : {ABDefinition} }
@@ -49,7 +49,11 @@ class ABFactory extends ABFactoryCore {
        *          DefinitionManager.Update(req, cond, values);
        * @param {ABUtil.request} req
        *        A req object tied to the proper tenant for this Factory.
-       *        Should be created by the
+       *        Should be created by the service (Bootstrap.js) when it
+       *        needs to communicate to a tenant.
+       * @param {ABFactory.Knex.connection()} knexConnection
+       *        An existing Knex Connection to reuse for this Factory.
+       *        (optional)
        */
 
       super(definitions);
@@ -61,7 +65,7 @@ class ABFactory extends ABFactoryCore {
       // {ABUtils.request} a tenant aware request object for interacting with
       // the data in our Tenant's db.
 
-      this._knexConn = null;
+      this._knexConn = knexConnection;
       // {Knex}
       // an instance of a {Knex} object that is tied to this Tenant's MySQL
       // connection settings. The base definition is found in config/local.js
@@ -516,4 +520,3 @@ class ABFactory extends ABFactoryCore {
 }
 
 module.exports = ABFactory;
-


### PR DESCRIPTION
The Production site was generating ER_CON_COUNT_ERROR errors in the Objection(Knex) library.

Every time a definition was edited/created our services would recreate an AB factory.  Each AB factory was creating a NEW Knex connection pool.  This eventually was using up all the mysql connections.

This update will reuse any existing Knex connection pools to reduce the number of open connections being established.

NOTE: our Mysql connections will scale by: `MYSQL_POOL_MAX` x `#Tenants` x `#ServicesThatUseKnex`

So the more tenants we host in the system the more connections that will be used.

If this becomes too much, the next step is to:
- review the Knex code (ABObjectModel) to verify every reference to a DB table is qualified as `tenantID`.`table name`
- then replace the `KnexPool` with a single `KnexConnection` that doesn't link to a specific DB.

This will reduce the mysql connections to: `MYSQL_POOL_MAX` x `#ServicesThatUseKnex`