### PR TITLE
[add] expose the ability to resetDefinitions() from the Factory

### DIFF
--- a/ABBootstrap.js
+++ b/ABBootstrap.js
@@ -167,4 +167,7 @@ module.exports = {
             .catch(reject);
       });
    },
+   resetDefinitions: (req) => {
+      staleHandler(req);
+   },
 };


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- [add] expose the ability to resetDefinitions() from the Factory
<!-- /release_notes --> 

In rare cases, a new definition might not be present in a service handler.  If detected, we want the ability for the handler to manually reset the definitions.