### PR TITLE
Adding isNil() utility fn to ABFactory

### DIFF
--- a/ABFactory.js
+++ b/ABFactory.js
@@ -494,6 +494,10 @@ class ABFactory extends ABFactoryCore {
       return _.isEmpty(...params);
    }
 
+   isNil(value) {
+      return _.isNil(value);
+   }
+
    isUndefined(...params) {
       return _.isUndefined(...params);
    }

--- a/utils/cleanReturnData.js
+++ b/utils/cleanReturnData.js
@@ -20,11 +20,14 @@
 module.exports = function (AB, currentObject, data, populate = false) {
    // NOTE: kept this as a promise for future possibilities of data we might
    // need to check or verify...
+   // make sure data is an array with no null or undefined entries.
+   if (!Array.isArray(data)) data = [data];
+   data = data.filter((d) => !AB.isNil(d));
 
    return new Promise((resolve /* , reject */) => {
       var UserObj = AB.objectUser();
       if (currentObject.id === UserObj.id) {
-         (data || []).forEach((r) => {
+         data.forEach((r) => {
             cleanEntry(r, populate);
          });
       } else {
@@ -32,7 +35,7 @@ module.exports = function (AB, currentObject, data, populate = false) {
          var connFields = currentObject.connectFields();
          (connFields || []).forEach((f) => {
             if ((f.datasourceLink || {}).id == UserObj.id) {
-               (data || []).forEach((r) => {
+               data.forEach((r) => {
                   var fdata = f.dataValue(r);
                   if (!Array.isArray(fdata)) {
                      fdata = [fdata];
@@ -84,6 +87,7 @@ function pruneRelations(object, data) {
    if (!Array.isArray(data)) data = [data];
    if (data.filter((row) => row != null).length == 0) return;
 
+   // find the connectedFields that are represented in the data object.
    let connectedFields = object
       .connectFields()
       .filter((f) => data[0]?.[f.relationName()]);


### PR DESCRIPTION
I'm adding an `.isNil()` utility fn to our ABFactory on all platforms.  Once included, I can use that as an easy check for `null` or `undefined` values in our `core` code.

## Release Notes
<!-- #release_notes -->
- [wip] added .isNil() utility to ABFactory
<!-- /release_notes --> 
