### PR TITLE
Various updates.

### DIFF
--- a/platform/ABIndex.js
+++ b/platform/ABIndex.js
@@ -153,13 +153,13 @@ module.exports = class ABIndex extends ABIndexCore {
       if (this.fields == null || !this.fields.length) {
          req.notify.builder(
             new Error(
-               `ABIndex[${this.name}][${this.id}] defined with no fields referenced`
+               `ABIndex[${this.name}][${this.id}] defined with no fields referenced`,
             ),
             {
                context: "ABIndex.migrateCreate()",
                field: this,
-               AB: this.AB,
-            }
+               // AB: this.AB,
+            },
          );
          return Promise.resolve();
       }
@@ -311,7 +311,7 @@ module.exports = class ABIndex extends ABIndexCore {
                   tableName,
                   indexName,
                   field: this,
-                  AB: this.AB,
+                  // AB: this.AB,
                });
 
                reject(err);

--- a/platform/ABObject.js
+++ b/platform/ABObject.js
@@ -525,7 +525,7 @@ module.exports = class ABClassObject extends ABObjectCore {
          req.notify.developer(err, {
             context: `field[${f.name || f.label}].migrateCreate(): error:`,
             field: f,
-            AB: this.AB,
+            // AB: this.AB,
          });
          throw err;
       });

--- a/platform/ABProcess.js
+++ b/platform/ABProcess.js
@@ -116,6 +116,12 @@ module.exports = class ABProcess extends ABProcessCore {
          }
          return defRecord;
       } catch (error) {
+         // strange edge case: numerous parallel calls can result in attempts
+         // to create the same entry >1 time.  If that is the case, these are
+         // those who weren't the first, so lets return this attempt again:
+         if (error.toString().indexOf("ER_DUP_ENTRY") > -1) {
+            return await this.instanceDefinition(req);
+         }
          this.AB.notify.developer(error, {
             context: "ABProcess.instanceDefinition",
             process: this.toObj(),

--- a/platform/dataFields/ABFieldConnect.js
+++ b/platform/dataFields/ABFieldConnect.js
@@ -316,25 +316,19 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
                   if (err) {
                      // if we already had that
                      if (err.code === "ER_DUP_FIELDNAME") {
-                        // req.notify.developer(err, {
-                        //    context: "ABFieldConnect.migrateCreate()",
-                        //    didExist,
-                        //    tableName,
-                        //    columnName: this.columnName,
-                        // });
                         resolve();
                         return;
                      }
-                     req.notify.developer(err, {
+                     this.AB.notify.developer(err, {
                         context: "ABFieldConnect.migrateCreate()",
                         field: this,
                         tableName,
                         columnName: this.columnName,
-                        AB: this.AB,
+                        // AB: this.AB,
                      });
                      reject(err);
                   } else resolve();
-               }
+               },
             );
          }
 
@@ -709,12 +703,12 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
                            req.notify.developer(err, {
                               context: "ABFieldConnect.migrateCreate()",
                               field: this,
-                              AB: this.AB,
+                              // AB: this.AB,
                            });
                            reject(err);
                         }
                      });
-               }
+               },
             );
          } else {
             resolve();


### PR DESCRIPTION
This is a set of changes as a result of working and viewing the logs.

I'm removing the AB factory from some log dumps.
I'm ensuring Knex migration calls are wrapped in req.retry()
I'm fixing an edge case in the process Trigger where multiple parallel requests of the same trigger can result in creating the same entry.


## Release Notes
<!-- #release_notes -->
- [fix] remove the AB factory from our Error messages
- [wip] wrap req.retry() around Knex migration calls
- [fix] edge case when instanceDefinition() would cause ER_DUP_ENTRY
<!-- /release_notes --> 

## Test Status
no new tests
