### PR TITLE
Fix Set Pluck Query task not properly gathering connected Data

### DIFF
--- a/platform/ql/ABQLSetPluck.js
+++ b/platform/ql/ABQLSetPluck.js
@@ -177,11 +177,17 @@ class ABQLSetPluck extends ABQLSetPluckCore {
                         value: this.AB.uniq(ids),
                      });
                   }
+               } else {
+                  // there were no ids, so let's make sure we don't gather anything
+                  nextContext._condition = cond;
+                  nextContext.object = linkObj;
+                  // nextContext.data = [];
+                  return nextContext;
                }
 
                return new Promise((resolve, reject) => {
                   req.retry(() =>
-                     linkObj.model().find({ where: cond, populate: true }, req)
+                     linkObj.model().find({ where: cond, populate: true }, req),
                   )
                      .then((rows) => {
                         // Special Formatting for Form.io fields.


### PR DESCRIPTION
A recent update to the ABQLSetPluck task caused it to not gather the connected data correctly.

The main issue was an improper call to `.findAll()` that didn't populate the column.  

## Release Notes
<!-- #release_notes -->
- [fix] improper call to .findAll() which doesn't populate our lookup column
<!-- /release_notes --> 

## Test Status
I'm too lazy to write a test ... maybe Isaac?
