### PR TITLE
Fix the missing json definitions on processes that are restarted.

### DIFF
--- a/platform/ABProcess.js
+++ b/platform/ABProcess.js
@@ -281,9 +281,17 @@ module.exports = class ABProcess extends ABProcessCore {
          // look up the full definition
          if (!instance.jsonDefinition && instance.definition) {
             try {
-               instance.jsonDefinition = await this.AB.objectProcessDefinition()
-                  .model()
-                  .find({ uuid: instance.definition }, req)[0];
+               let defs = await req.retry(() =>
+                  this.AB.objectProcessDefinition()
+                     .model()
+                     .find({ uuid: instance.definition }, req),
+               );
+               if (defs.length == 0) {
+                  throw new Error(
+                     `No Process Instance found for uuid[${instance.definition}]`,
+                  );
+               }
+               instance.jsonDefinition = defs[0];
             } catch (err) {
                this.AB.notify.developer(err, {
                   context: "Error getting instance definition (ABProcess.run)",

--- a/platform/process/tasks/ABProcessTaskUserApproval.js
+++ b/platform/process/tasks/ABProcessTaskUserApproval.js
@@ -61,6 +61,7 @@ module.exports = class ABProcessTaskUserApproval extends (
             );
          }
       });
+
       jobData.data = processData;
 
       if (parseInt(this.who) == 1) {
@@ -83,15 +84,13 @@ module.exports = class ABProcessTaskUserApproval extends (
 
             if (Array.isArray(usedFields) && usedFields?.length) {
                usedFields.forEach((f) => {
-                  let foundUser = this.process.processData(this, [
-                     instance,
-                     f,
-                  ]);
+                  let foundUser = this.process.processData(this, [instance, f]);
                   if (foundUser) {
-                     if (!Array.isArray(foundUser))
-                        foundUser = [foundUser];
+                     if (!Array.isArray(foundUser)) foundUser = [foundUser];
 
-                     jobData.users = jobData.users.concat(foundUser.map((u) => u.uuid || u.id || u.username || u));
+                     jobData.users = jobData.users.concat(
+                        foundUser.map((u) => u.uuid || u.id || u.username || u),
+                     );
                   }
                });
             }


### PR DESCRIPTION
OK, so not sure why it wasn't working, but we kept getting errors after a process was restarted and needed to lookup its jsonDefinition.  For some reason this code:
```
               instance.jsonDefinition = await this.AB.objectProcessDefinition()
                  .model()
                  .find({ uuid: instance.definition }, req)[0];
```

would just result in `undefined` 

My guess is that the compiler's would misinterpret the `[0]` reference along with the `await`. 

Who knows.  Instead these changes fix the issue and also adds more error protections in place.

## Release Notes
<!-- #release_notes -->
- [fix] make sure the json definitions are properly loaded into a process instance
- [wip] eslint changes
<!-- /release_notes --> 

## Test Status
none.  who does these?
