### PR TITLE
Additional compression of our form.io data

### DIFF
--- a/platform/ABProcess.js
+++ b/platform/ABProcess.js
@@ -122,6 +122,7 @@ module.exports = class ABProcess extends ABProcessCore {
          if (error.toString().indexOf("ER_DUP_ENTRY") > -1) {
             return await this.instanceDefinition(req);
          }
+
          this.AB.notify.developer(error, {
             context: "ABProcess.instanceDefinition",
             process: this.toObj(),

--- a/platform/process/tasks/ABProcessTaskUserApproval.js
+++ b/platform/process/tasks/ABProcessTaskUserApproval.js
@@ -62,26 +62,27 @@ function parseEntryArrays(entries, data) {
    }
 
    let entry = entries.shift();
-   if (entry.components) {
-      if (
-         entry.path &&
-         entry.template /* && entry.customClass == "customList" */
-      ) {
-         // if entry.path refers to one of our entries:
-         let dataSet = data[entry.path];
-         if (dataSet && dataSet.length) {
-            let fieldsToKeep = parseEntryArrayFields(entry);
 
-            for (let i = 0; i < dataSet.length; i++) {
-               let d = dataSet[i];
-               Object.keys(d).forEach((k) => {
-                  if (fieldsToKeep.indexOf(k) == -1) {
-                     delete d[k];
-                  }
-               });
-            }
+   if (
+      entry.path &&
+      entry.templates /* && entry.customClass == "customList" */
+   ) {
+      // if entry.path refers to one of our entries:
+      let dataSet = data[entry.path];
+      if (dataSet && dataSet.length) {
+         let fieldsToKeep = parseEntryArrayFields(entry);
+
+         for (let i = 0; i < dataSet.length; i++) {
+            let d = dataSet[i];
+            Object.keys(d).forEach((k) => {
+               if (fieldsToKeep.indexOf(k) == -1) {
+                  delete d[k];
+               }
+            });
          }
-      } else {
+      }
+   } else {
+      if (entry.components) {
          // this is a layout component, so scan it's children
          parseEntryArrays(entry.components, data);
       }
@@ -102,47 +103,18 @@ function parseEntryArrays(entries, data) {
  *        The processData that we need to pair down.
  */
 function parseEntryArrayFields(entry) {
-   let fields = [];
+   let fieldHash = {};
    try {
-      let allMatches = [...JSON.stringify(entry).matchAll(/row\['(.+)'\]/g)];
+      let allMatches = [
+         ...JSON.stringify(entry).matchAll(/row\['([a-zA-Z_.0-9 ]+)'\]/g),
+      ];
       (allMatches || []).forEach((match) => {
-         fields.push(match[1]);
+         fieldHash[match[1]] = match;
       });
    } catch (e) {
       console.error(e);
    }
-
-   // entry.components.forEach((comp) => {
-   //    if (comp.components) {
-   //       // this is another layout element ... parse it:
-   //       let compFields = parseEntryArrayFields(comp);
-   //       if (compFields.length > 0) {
-   //          fields = fields.concat(compFields);
-   //       }
-   //    } else {
-   //       let field = comp.key;
-   //       if (comp.calculateValue) {
-   //          let match = [...comp.calculateValue.matchAll(/row\['(.+)'\]/g)][0];
-   //          if (match) {
-   //             field = match[1];
-   //          }
-   //       }
-   //       if (comp.attrs) {
-   //          try {
-   //             let match = [
-   //                ...JSON.stringify(comp.attrs).matchAll(/row\['(.+)'\]/g),
-   //             ][0];
-   //             if (match) {
-   //                field = match[1];
-   //             }
-   //          } catch (e) {
-   //             console.error(e);
-   //          }
-   //       }
-   //       fields.push(field);
-   //    }
-   // });
-   return fields;
+   return Object.keys(fieldHash);
 }
 
 module.exports = class ABProcessTaskUserApproval extends (
@@ -234,10 +206,6 @@ module.exports = class ABProcessTaskUserApproval extends (
 
       // reduce the amount of data we are storing to only the ones referenced
       // by the formBuilder information:
-      /* 
-
-      // TODO: Test this once the UI is working for the embedded templates
-         It currently isn't displaying the data correctly without my changes.
 
       // 1) only keep keys that are used in the form:
       let keysToKeep = [];
@@ -253,7 +221,6 @@ module.exports = class ABProcessTaskUserApproval extends (
       //    we actually reference
       copyComponents = this.AB.cloneDeep(this.formBuilder.components);
       parseEntryArrays(copyComponents, processData);
-*/
 
       jobData.data = processData;
 

--- a/platform/process/tasks/ABProcessTaskUserApproval.js
+++ b/platform/process/tasks/ABProcessTaskUserApproval.js
@@ -108,7 +108,7 @@ function parseEntryArrayFields(entry) {
       let allMatches = [
          ...JSON.stringify(entry).matchAll(/row\['([a-zA-Z_.0-9 ]+)'\]/g),
       ];
-      (allMatches || []).forEach((match) => {
+      allMatches.forEach((match) => {
          fieldHash[match[1]] = match;
       });
    } catch (e) {

--- a/platform/ql/ABQLSetPluck.js
+++ b/platform/ql/ABQLSetPluck.js
@@ -219,14 +219,15 @@ class ABQLSetPluck extends ABQLSetPluckCore {
                         (linkedConnections || []).forEach((f) => {
                            (rows || []).forEach((r) => {
                               if (Array.isArray(r[f.relationName()])) {
-                                 r[f.relationName()] = r[f.relationName()].map((rItem) => {
-                                    return {
-                                       id: rItem.id,
-                                       uuid: rItem.uuid,
-                                    };
-                                 });
-                              }
-                              else if (r[f.relationName()]) {
+                                 r[f.relationName()] = r[f.relationName()].map(
+                                    (rItem) => {
+                                       return {
+                                          id: rItem.id,
+                                          uuid: rItem.uuid,
+                                       };
+                                    },
+                                 );
+                              } else if (r[f.relationName()]) {
                                  r[f.relationName()] = {
                                     id: r[f.relationName()].id,
                                     uuid: r[f.relationName()].uuid,


### PR DESCRIPTION
We had been getting NETWORK_PACKET_TOO_LARGE errors.  I think the actual problem was that we had a bug where we were gathering ALL receipts and report items instead of just the ones for our entry.  

However, in the process of trying to reduce the data we were sending and saving as part of the form.io data, I came up with this optimization to only send the fields in our data that were being referenced in our form.io components.

## Release Notes
<!-- #release_notes -->
- [wip] reduce the amount of data that is stored in our processData for the formbuilder.io
- [wip] eslint changes
- [wip] take a more aggressive scan of our customList formio entries.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
