### PR TITLE
Fix user many:many condition bug

### DIFF
--- a/platform/ABObject.js
+++ b/platform/ABObject.js
@@ -5,7 +5,7 @@ const ABObjectCore = require(path.join(
    __dirname,
    "..",
    "core",
-   "ABObjectCore.js",
+   "ABObjectCore.js"
 ));
 // const Model = require("objection").Model;
 // const ABModel = require(path.join(__dirname, "ABModel.js"));
@@ -64,7 +64,7 @@ module.exports = class ABClassObject extends ABObjectCore {
          let currViewId = attributes.objectWorkspaceViews.currentViewID;
 
          let currView = attributes.objectWorkspaceViews.list.filter(
-            (v) => v.id == currViewId,
+            (v) => v.id == currViewId
          )[0];
          if (currView) {
             this.objectWorkspace.filterConditions =
@@ -85,7 +85,7 @@ module.exports = class ABClassObject extends ABObjectCore {
          } else {
             let appName = app.name || "GEN";
             this.tableName = this.AB.rules.toObjectNameFormat(
-               `${appName}_${this.name}`,
+               `${appName}_${this.name}`
             );
          }
 
@@ -220,7 +220,7 @@ module.exports = class ABClassObject extends ABObjectCore {
             // export object
             // export fields that don't connect to other NonSystemObjects
             exportObject(
-               (f) => !f.isConnection || f.datasourceLink.isSystemObject,
+               (f) => !f.isConnection || f.datasourceLink.isSystemObject
             );
          }
 
@@ -286,13 +286,13 @@ module.exports = class ABClassObject extends ABObjectCore {
             SiteUser.find({
                where: { username: condDefaults.username, isActive: 1 },
                populate: ["SITE_ROLE", "SITE_SCOPE"],
-            }),
+            })
          ).then((list) => {
             var user = list[0];
             if (!user) {
                // This is unexpected ...
                var error = new Error(
-                  `ABObject.includeScopes(): unknown or inactive user[${condDefaults.username}] `,
+                  `ABObject.includeScopes(): unknown or inactive user[${condDefaults.username}] `
                );
                req.notify.developer(error, {
                   context:
@@ -335,12 +335,12 @@ module.exports = class ABClassObject extends ABObjectCore {
 
                req.notify.developer(
                   new Error(
-                     "ABObject.includeScopes(): user has NO ROLES : preventing data access",
+                     "ABObject.includeScopes(): user has NO ROLES : preventing data access"
                   ),
                   {
                      context: "ABObject.includeScopes(): user has NO ROLES",
                      condDefaults,
-                  },
+                  }
                );
                // but continue on since this isn't technically an Error ...
                return resolve();
@@ -465,7 +465,7 @@ module.exports = class ABClassObject extends ABObjectCore {
             (indx.fields || []).filter((f) => f.isConnection).length > 0;
          if (hasConnect) {
             console.log(
-               `:::: STASHING INDEX O[${this.label}].I[${indx.indexName}]`,
+               `:::: STASHING INDEX O[${this.label}].I[${indx.indexName}]`
             );
             this._stashIndexes.push(indx);
             this._indexes = this.indexes(function (o) {
@@ -591,7 +591,7 @@ module.exports = class ABClassObject extends ABObjectCore {
             //// let's go add our normal fields to it:
 
             let normalFields = this.fields(
-               (f) => f && !nonNormalFields.find((c) => c.id == f.id),
+               (f) => f && !nonNormalFields.find((c) => c.id == f.id)
             );
 
             // {fix} ER_TABLE_EXISTS_ERROR: Table '`appbuilder-admin`.`#sql-alter-1-67`' already exists"
@@ -640,7 +640,7 @@ module.exports = class ABClassObject extends ABObjectCore {
                   req.log(
                      `    ... creating -> O[${
                         this.name || this.label
-                     }]->table[${tableName}]`,
+                     }]->table[${tableName}]`
                   );
 
                   return req
@@ -662,7 +662,7 @@ module.exports = class ABClassObject extends ABObjectCore {
 
                            // Adding a new field to store various item properties in JSON (ex: height)
                            t.text("properties");
-                        }),
+                        })
                      )
                      .then(() => {
                         return this.migrateCreateFields(req, knex);
@@ -673,7 +673,7 @@ module.exports = class ABClassObject extends ABObjectCore {
                   req.log(
                      `    ... exists -> O[${
                         this.name || this.label
-                     }] -> table[${tableName}]`,
+                     }] -> table[${tableName}]`
                   );
 
                   // the Object might already exist,  but we need to make sure any added
@@ -1142,7 +1142,7 @@ module.exports = class ABClassObject extends ABObjectCore {
    requestParams(allParameters) {
       var usefulParameters = {};
       this.fields(
-         (f) => !f.isConnection || (f.isConnection && f.linkType() != "many"),
+         (f) => !f.isConnection || (f.isConnection && f.linkType() != "many")
       ).forEach((f) => {
          var p = f.requestParam(allParameters);
          if (p) {
@@ -1272,7 +1272,7 @@ module.exports = class ABClassObject extends ABObjectCore {
                      processPolicy(indx + 1, cb);
                   }
                },
-               req,
+               req
             );
             /*
              * OLD FORMAT:
@@ -1361,7 +1361,7 @@ module.exports = class ABClassObject extends ABObjectCore {
                   // Check user in role
                   if (
                      !(r.users || []).filter(
-                        (u) => (u.id || u) == options.username,
+                        (u) => (u.id || u) == options.username
                      )[0]
                   )
                      return;
@@ -1369,7 +1369,7 @@ module.exports = class ABClassObject extends ABObjectCore {
                   (r.scopes__relation || []).forEach((sData) => {
                      if (
                         !scopes.filter(
-                           (s) => (s.id || s.uuid) == (sData.id || sData.uuid),
+                           (s) => (s.id || s.uuid) == (sData.id || sData.uuid)
                         )[0]
                      )
                         scopes.push(sData);
@@ -1413,7 +1413,7 @@ module.exports = class ABClassObject extends ABObjectCore {
     *
     * @return Promise
     */
-   processFilterPolicy(_where, userData) {
+   /*   processFilterPolicy(_where, userData) {
       // list of all the condition filtering policies we want our defined
       // filters to pass through:
       const PolicyList = [
@@ -1475,7 +1475,7 @@ module.exports = class ABClassObject extends ABObjectCore {
          });
       });
    }
-
+*/
    selectFormulaFields(query) {
       // Formula fields
       let formulaFields = this.fields((f) => f.key == "formula");
@@ -1485,7 +1485,7 @@ module.exports = class ABClassObject extends ABObjectCore {
             // selectSQL += ` AS ${this.dbTableName(true)}.${f.columnName}`;
             selectSQL += ` AS \`${f.columnName}\``;
             query = query.select(
-               this.AB.Knex.connection(/* connectionName */).raw(selectSQL),
+               this.AB.Knex.connection(/* connectionName */).raw(selectSQL)
             );
          }
       });
@@ -1534,8 +1534,8 @@ module.exports = class ABClassObject extends ABObjectCore {
          }\`)
                   FROM ${connectedObj.dbTableName(true)}
                   WHERE ${connectedObj.dbTableName(true)}.\`${
-                     linkField.columnName
-                  }\` = ${this.dbTableName(true)}.\`${this.PK()}\`)`;
+            linkField.columnName
+         }\` = ${this.dbTableName(true)}.\`${this.PK()}\`)`;
       }
       // 1:M , 1:1 isSource: true
       else if (
@@ -1550,10 +1550,10 @@ module.exports = class ABClassObject extends ABObjectCore {
          }\`)
                   FROM ${connectedObj.dbTableName(true)}
                   WHERE ${connectedObj.dbTableName(
-                     true,
+                     true
                   )}.\`${connectedObj.PK()}\` = ${this.dbTableName(true)}.\`${
-                     connectedField.columnName
-                  }\`)`;
+            connectedField.columnName
+         }\`)`;
       }
       // M:N
       else if (
@@ -1569,11 +1569,11 @@ module.exports = class ABClassObject extends ABObjectCore {
                FROM ${connectedObj.dbTableName(true)}
                INNER JOIN ${joinTable}
                ON ${joinTable}.\`${
-                  joinColumnNames.targetColumnName
-               }\` = ${connectedObj.dbTableName(true)}.${connectedObj.PK()}
+            joinColumnNames.targetColumnName
+         }\` = ${connectedObj.dbTableName(true)}.${connectedObj.PK()}
                WHERE ${joinTable}.\`${
-                  joinColumnNames.sourceColumnName
-               }\` = ${this.dbTableName(true)}.\`${this.PK()}\`)`;
+            joinColumnNames.sourceColumnName
+         }\` = ${this.dbTableName(true)}.\`${this.PK()}\`)`;
       }
 
       return selectSQL;
@@ -1585,7 +1585,7 @@ module.exports = class ABClassObject extends ABObjectCore {
             .replace("{prefix}", f.dbPrefix())
             .replace(
                "{columnName}",
-               fCustomIndex ? fCustomIndex.columnName : f.object.PK(),
+               fCustomIndex ? fCustomIndex.columnName : f.object.PK()
             );
       };
 

--- a/platform/ABObject.js
+++ b/platform/ABObject.js
@@ -20,6 +20,7 @@ const ConversionList = [
 
 const PolicyList = [
    require("../policies/ABModelConvertDataCollectionCondition"),
+   require("../policies/ABModelConvertIsUserMNConditions"),
    require("../policies/ABModelConvertSameAsUserConditions"),
    require("../policies/ABModelConvertQueryConditions"),
    require("../policies/ABModelConvertQueryFieldConditions"),

--- a/policies/ABModelConvertIsUserMNConditions.js
+++ b/policies/ABModelConvertIsUserMNConditions.js
@@ -1,0 +1,133 @@
+/**
+ * ABModelConvertIsUserMNConditions
+ *
+ * @module      :: Policy
+ * @description :: Scan any provided conditions to see if we have a 'is_current_user'
+ *                 or 'not_is_current_user' clause that references a connection that is
+ *                 many:many.  If we do, convert it to an IN or NOT IN clause.
+ *
+ * @docs        :: http://sailsjs.org/#!documentation/policies
+ *
+ */
+
+module.exports = function (AB, where, object, userData, next, req) {
+   // our QB Conditions look like:
+   // {
+   //   "glue": "and",
+   //   "rules": [{
+   //     "key": "name_first",
+   //     "rule": "begins_with",
+   //     "value": "a"
+   //   }, {
+   //     "key": "name_family",
+   //     "rule": "begins_with",
+   //     "value": "a"
+   //   }, {
+   //     "glue": "or",
+   //     "rules": [{
+   //       "glue": "and",
+   //       "rules": [{
+   //         "key": "name_first",
+   //         "rule": "not_begins_with",
+   //         "value": "Apple"
+   //       }, {
+   //         "key": "name_family",
+   //         "rule": "not_contains",
+   //         "value": "Pie"
+   //       }]
+   //     }, {
+   //       "glue": "and",
+   //       "rules": [{
+   //         "key": "name_first",
+   //         "rule": "ends_with",
+   //         "value": "Crumble"
+   //       }, {
+   //         "key": "name_family",
+   //         "rule": "equal",
+   //         "value": "Goodness"
+   //       }]
+   //     }]
+   //   }]
+   // }
+   //
+   //
+
+   // move along if no or empty where clause
+   if (AB.isEmpty(where)) {
+      next();
+      return;
+   }
+
+   parseCondition(
+      AB,
+      where,
+      object,
+      userData,
+      (err) => {
+         next(err);
+      },
+      req
+   );
+};
+
+/**
+ * @function findEntry
+ * analyze the current condition to see if it is one we are looking for.
+ * if it is a grouping entry ( 'and', 'or') then search it's children looking
+ * for an entry as well.
+ * if no entry is found, return null.
+ * @param {obj} a condition entry
+ * @return {obj} a condition entry that matches our type we are looking for:
+ */
+function findEntry(_where, object) {
+   if (!_where) return null;
+
+   if (_where.rules) {
+      var entry = null;
+      for (var i = 0; i < _where.rules.length; i++) {
+         entry = findEntry(_where.rules[i], object);
+         if (entry) {
+            return entry;
+            // break;
+         }
+      }
+      return entry;
+   } else {
+      if (
+         _where.rule == "is_current_user" ||
+         _where.rule == "is_not_current_user"
+      ) {
+         let field = object.fieldByID(_where.key);
+         if (field) {
+            let link = `${field.linkType()}:${field.linkViaType()}`;
+            if (link == "many:many") {
+               return _where;
+            }
+         }
+      }
+      return null;
+   }
+}
+
+function parseCondition(AB, where, object, userData, cb, req) {
+   var cond = findEntry(where, object);
+   if (!cond) {
+      cb();
+   } else {
+      let field = object.fieldByID(cond.key);
+      if (!field) {
+         var error = AB.toError("improperly formed lookup.", {
+            location: "ABModelConvertIsUserMNConditions",
+            cond,
+         });
+         cb(error);
+         return;
+      }
+
+      /// now we just change this to
+      cond.rule = cond.rule == "is_current_user" ? "in" : "not_in";
+      cond.value = [userData.username];
+
+      parseCondition(AB, where, object, userData, cb, req);
+   } // if !cond
+}


### PR DESCRIPTION
When you perform an `is_current_user` / `is_not_current_user` condition on a User field that is a `many:many` connection, our code was still expecting the `user` field to be on the table.

However, now our `v2` code treats this as a connection, and we were getting 
```
ER_BAD_FIELD_ERROR: Unknown column 'appbuilder-admin.AB_Projectw.Project Owner' in 'where clause
```

Since they are connections, we can simply convert that particular condition into an `in` / `not_in` condition and our code will handle it properly.

NOTE: this is only for situations where the connection is `many:many`. In the other situations, our current code it sufficient. 


## Release Notes
<!-- #release_notes -->
- [fix] convert is_current_user to an IN condition if connection is many:many
- [wip] eslint changes
<!-- /release_notes --> 


