### PR TITLE
Properly reference index fields in unRelate() operations

### DIFF
--- a/platform/ABModel.js
+++ b/platform/ABModel.js
@@ -2582,11 +2582,17 @@ function unRelate(obj, columnName, rowId, values, trx, req) {
             let objectLink = fieldLink.object;
             if (objectLink == null) return done(resolve, alias, req);
 
+            // NOTE: if our field has linked to an index value, we have to use that
+            // columnName here:
+            let PK = fieldLink.indexField
+               ? fieldLink.indexField.columnName
+               : objectLink.PK();
+
             record
                .$relatedQuery(clearRelationName)
                .alias(alias)
                .unrelate()
-               .where(objectLink.PK(), "in", values)
+               .where(PK, "in", values)
                .then(() => {
                   done(resolve, alias, req);
                })


### PR DESCRIPTION
This is a fix for [ns_app#550](https://github.com/digi-serve/ns_app/issues/550)

## Release Notes
<!-- #release_notes -->
- [fix] properly reference index fields in unRelate() operations
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
