### PR TITLE
CSV Packing of Data (service platform) 

### DIFF
--- a/ABFactory.js
+++ b/ABFactory.js
@@ -10,6 +10,7 @@ const Knex = require("knex");
 const moment = require("moment");
 const { serializeError, deserializeError } = require("serialize-error");
 const uuid = require("uuid");
+const Papa = require("papaparse");
 
 var ABFactoryCore = require("./core/ABFactoryCore");
 
@@ -581,6 +582,17 @@ class ABFactory extends ABFactoryCore {
 
    toJSON() {
       return { tenantID: this.req.tenantID() };
+   }
+
+   csvToJson(csvData) {
+      return Papa.parse(csvData, {
+         header: true,
+         skipEmptyLines: true,
+      });
+   }
+
+   jsonToCsv(jsonData) {
+      return Papa.unparse(jsonData);
    }
 }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "oauth-1.0a": "^2.2.6",
     "object-hash": "^3.0.0",
     "objection": "github:Hiro-Nakamura/objection.js#fixDBErrors",
+    "papaparse": "^5.5.2",
     "semver": "^7.7.1",
     "serialize-error": "^8.0.1",
     "xml-js": "^1.6.11"


### PR DESCRIPTION
Initial Implementation of CSV Packing of our Data.

Currently we have been using json as our exchange format between our client and server.  For for larger data sets, the json format repeats a lot of data for the field names. ex:
```
[ 
	{
		"firstName": "Neo",
		"lastName" : "Andersong",
	},
	{
		"firstName": "Morpheous",
		"lastName" : "",
	},
	{
		"firstName": "Trinity",
		"lastName" : ""
	}
]
```

using csv, we can reduce the repeated column information:
```
firstName,lastName
"Neo","Anderson"
"Morpheous",""
"Trinity",""
```

The larger the dataset, the greater the savings. 

The previous data exchange format was
```
{
    data: [{obj1}, {obj2}, ... {objN}],
    total_bytes:xx,
}
```
This change now encodes our data in the following format:
```
{
  csv_packed:{
    data: "csv of primary data",
    relations: {
      {connectionFieldID}: "csv of relation data", // each entry has entry._csvID, that is the lookup
      {connectionFieldID}: "csv of relation data",
      ...
  }
  total_bytes:xx,
}
```

This will happen for any direct request to the appbuilder.model-get, model-patch, model-update services as well as any broadcast that happens as a result of one of those operations.

This PR is part of a series of updates: [class_core](https://github.com/digi-serve/appbuilder_class_core/pull/290), [platform_web](https://github.com/digi-serve/ab_platform_web/pull/646), [platform_service](https://github.com/digi-serve/appbuilder_platform_service/pull/168), [appbuilder service](https://github.com/digi-serve/ab_service_appbuilder/pull/119)

## Release Notes
<!-- #release_notes -->
- [wip] Implement CSV Packing on the service platform
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
