### PR TITLE
Include jobID() in our ABFactory

### DIFF
--- a/ABFactory.js
+++ b/ABFactory.js
@@ -8,6 +8,7 @@
 const _ = require("lodash");
 const Knex = require("knex");
 const moment = require("moment");
+const nanoid = require("nanoid");
 const { serializeError, deserializeError } = require("serialize-error");
 const uuid = require("uuid");
 
@@ -561,6 +562,10 @@ class ABFactory extends ABFactoryCore {
 
    isUndefined(...params) {
       return _.isUndefined(...params);
+   }
+
+   jobID(length = 21) {
+      return nanoid(length);
    }
 
    merge(...params) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.7.7",
     "ejs": "^3.1.8",
     "moment": "^2.29.1",
+    "nanoid": "^3.3.11",
     "oauth-1.0a": "^2.2.6",
     "object-hash": "^3.0.0",
     "objection": "github:Hiro-Nakamura/objection.js#fixDBErrors",

--- a/platform/ABModelApiNetsuite.js
+++ b/platform/ABModelApiNetsuite.js
@@ -136,7 +136,7 @@ function fetchConcurrent(
    headers = {}
 ) {
    concurrency_count++;
-   let jobID = AB.uuid();
+   let jobID = AB.jobID(10);
    if (Object.keys(RequestsActive).length >= CONCURRENCY_LIMIT_MAX) {
       // we are at our limit, so we need to wait until we have an open slot
       let p = new Promise((resolve, reject) => {


### PR DESCRIPTION
Every other platform's ABFactory includes `.jobID()`.  

I'm including it here too for consistency.

## Release Notes
<!-- #release_notes -->
- [wip] include jobID() in our ABFactory
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
