### PR TITLE
Fix Missing reference to modelKnex()

### DIFF
--- a/platform/ABModel.js
+++ b/platform/ABModel.js
@@ -914,7 +914,9 @@ module.exports = class ABModel extends ABModelCore {
          var linkField = f.fieldLink;
          if (linkField == null) return;
 
-         var linkModel = linkObject.model().modelKnex();
+         var linkModel = linkObject.model().modelKnex?.();
+         if (!linkModel) return;
+         
          var relationName = f.relationName();
 
          var LinkType = `${f.settings.linkType}:${f.settings.linkViaType}`;


### PR DESCRIPTION
Watching the boot up logs on the live `hrupdate` site, I saw this error cropping up:
```
{
    "domain": "developer",
    "error":
    {
        "__context":
        [
            ".find().findAll().catch():throw err"
        ],
        "name": "TypeError",
        "message": "linkObject.model(...).modelKnex is not a function",
        "stack": "TypeError: linkObject.model(...).modelKnex is not a function\n    at /app/AppBuilder/platform/ABModel.js:917:45\n    at Array.forEach (<anonymous>)\n    at ABModel.modelKnexRelation (/app/AppBuilder/platform/ABModel.js:909:21)\n    at MyModel.relationMappings (/app/AppBuilder/platform/ABModel.js:877:25)\n    at getRelationMappings (/app/AppBuilder/node_modules/objection/lib/model/Model.js:919:41)\n    at cachedGet (/app/AppBuilder/node_modules/objection/lib/model/Model.js:867:61)\n    at ceaadeaecd.getRelationMappings (/app/AppBuilder/node_modules/objection/lib/model/Model.js:484:12)\n    at getRelationNames (/app/AppBuilder/node_modules/objection/lib/model/Model.js:926:33)\n    at cachedGet (/app/AppBuilder/node_modules/objection/lib/model/Model.js:867:61)\n    at ceaadeaecd.getRelationNames (/app/AppBuilder/node_modules/objection/lib/model/Model.js:498:12)"
    },
    "info":
    {
        "context": "Service:user_manager.config-meta: Error gathering meta",
        "tenantID": "1729957e-d3ba-4cd4-901c-aa17982b9766",
        "jobID": "ABFactory(1729957e-d3ba-4cd4-901c-aa17982b9766)",
        "requestID": "??",
        "serviceKey": "user_manager",
        "user":
        {}
    },
    "callStack": "Error: just getting my stack\n    at ABNotification.notify (/app/node_modules/@digiserve/ab-utils/utils/reqNotification.js:26:22)\n    at ABRequestService.notify (/app/node_modules/@digiserve/ab-utils/utils/reqService.js:583:27)\n    at ABRequestService.notify.developer (/app/node_modules/@digiserve/ab-utils/utils/reqService.js:194:15)\n    at /app/handlers/config-meta.js:82:30\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
}
```

So I'm now checking for modelKnex() to be present.

## Release Notes
<!-- #release_notes -->
- [fix] prevent errors when a model doesn't have a .modelKnex() reference
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
