### PR TITLE
Netsuite Paging with non standard offset/limit combinations

### DIFF
--- a/platform/ABModelApiNetsuite.js
+++ b/platform/ABModelApiNetsuite.js
@@ -1440,7 +1440,7 @@ module.exports = class ABModelAPINetsuite extends ABModel {
       if (cond.offset > 0 && cond.limit > 0) {
          let mod = cond.offset % cond.limit;
          if (mod != 0) {
-            // Netsuite needs offset to be a mutiple of limit
+            // Netsuite needs offset to be a multiple of limit
             // however, our ui library has widgets that can request
             // offsets and limits that are not multiples of each other.
             // For example: offset:75 limit:20


### PR DESCRIPTION
OK, apparently Netsuite requires `offset` to be a multiple of `limit` when setting the paging parameters.

For normal paging, this isn't much of a problem. However some of our UI widgets ( I'm looking at you "grid" ) can decide to request odd pages where the `offset` isn't a multiple of `limit`.

Just go to the AB Designer, pull up an object table with a Netsuite object, and randomly scroll down to an arbitrary place. There is a good chance you'll see a request with offset=783 and limit=20.

Obviously Netsuite has some harsh things to say in that situation.  But we still want it anyway, so ....

This patch will attempt to find the proper offset/limit boundaries around the actual piece of data we are requesting. Request both of those, and then pull out the actual data we were requested.

## Release Notes
<!-- #release_notes -->
- [fix] handle odd offset/limit combinations in Netsuite
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
