### PR TITLE
Fix Netsuite Counts when there are 0 results

### DIFF
--- a/platform/ABModelApiNetsuite.js
+++ b/platform/ABModelApiNetsuite.js
@@ -1662,7 +1662,7 @@ module.exports = class ABModelAPINetsuite extends ABModel {
          list = list.concat(response.data.items);
 
          // if there is a count request, then resolve it now
-         if (!hasCountUpdated && response.data.totalResults) {
+         if (!hasCountUpdated) {
             let currCountJob = PendingCountRequests[cond.jobID];
             if (currCountJob) {
                currCountJob.res(response.data.totalResults);

--- a/platform/ABModelApiNetsuite.js
+++ b/platform/ABModelApiNetsuite.js
@@ -78,6 +78,15 @@ setInterval(() => {
          `NetSuite API Concurrency: ${RequestsPending.length} pending requests`
       );
    }
+   let countPendingCounts = Object.keys(PendingCountRequests).length;
+   if (countPendingCounts > 0) {
+      displayLog.push(
+         `NetSuite Pending Counts (${countPendingCounts}): ${Object.keys(
+            PendingCountRequests
+         ).join(", ")}`
+      );
+   }
+
    concurrency_count = 0;
    if (displayLog.length > 0) {
       console.log("=== Netsuite Concurrency ====");


### PR DESCRIPTION
OK, we need to respond with our counts properly when 0 results are returned from our calls.

## Release Notes
<!-- #release_notes -->
- [fix] make sure Netsuite Counts work when there are 0 results
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
