### PR TITLE
Netsuite Paging in parallel

### DIFF
--- a/platform/ABModelApiNetsuite.js
+++ b/platform/ABModelApiNetsuite.js
@@ -1365,6 +1365,9 @@ module.exports = class ABModelAPINetsuite extends ABModel {
    async populate(cond, data, req) {
       let columns = [];
 
+      // don't need to populate anything if there is no data.
+      if (data.length == 0) return;
+
       // if .populate == false
       // if .populate not set, assume no
       if (!cond.populate || cond.populate === "false") return;

--- a/platform/ABModelApiNetsuite.js
+++ b/platform/ABModelApiNetsuite.js
@@ -1789,17 +1789,26 @@ module.exports = class ABModelAPINetsuite extends ABModel {
          await this.populate(cond, list, req);
          if (req) {
             req.performance.measure("populate");
+            req.performance.mark("normalize");
          }
          this.normalizeData(list);
+         if (req) {
+            req.performance.measure("normalize");
+         }
          return list;
       } catch (err) {
-         err.q = sql;
-         this.processError(
-            `POST ${URL}`,
-            `Error finding ${this.object.dbTableName()} data`,
-            err,
-            req
-         );
+         // if this is an error from an api call:
+         if (err.response) {
+            err.q = sql;
+            this.processError(
+               `POST ${URL}`,
+               `Error finding ${this.object.dbTableName()} data`,
+               err,
+               req
+            );
+         } else {
+            throw err;
+         }
       }
    }
 

--- a/platform/ABModelApiNetsuite.js
+++ b/platform/ABModelApiNetsuite.js
@@ -1080,9 +1080,9 @@ module.exports = class ABModelAPINetsuite extends ABModel {
       let where = {};
       where[PK] = pks;
       if (req) {
-         values = await req.retry(() => linkObj.model().find(where));
+         values = await req.retry(() => linkObj.model().find(where, req));
       } else {
-         values = await linkObj.model().find(where);
+         values = await linkObj.model().find(where, req);
       }
 
       // convert to a hash  ID : { value }
@@ -1158,9 +1158,9 @@ module.exports = class ABModelAPINetsuite extends ABModel {
       let col = linkField.columnName;
       where[col] = pks;
       if (req) {
-         values = await req.retry(() => linkObj.model().find(where));
+         values = await req.retry(() => linkObj.model().find(where, req));
       } else {
-         values = await linkObj.model().find(where);
+         values = await linkObj.model().find(where, req);
       }
 
       if (typeof values == "undefined") values = [];

--- a/platform/ABModelApiNetsuite.js
+++ b/platform/ABModelApiNetsuite.js
@@ -1675,7 +1675,6 @@ module.exports = class ABModelAPINetsuite extends ABModel {
             let currCountJob = PendingCountRequests[cond.jobID];
             if (currCountJob) {
                currCountJob.res(response.data.totalResults);
-               hasCountUpdated = true;
                delete PendingCountRequests[cond.jobID];
             }
          }


### PR DESCRIPTION
OK, the last update to make sure our Netsuite objects requested all their data, did so sequentially.

But when there were > 23 different pages of data to pull, this ended up taking a lot of time.

We will try to speed things up, by making all those additional calls in parallel.

## Release Notes
<!-- #release_notes -->
- [wip] switch the Paging step to issue all requests in parallel.
- [wip] make sure our populate() code passes along the request object
- [wip] prevent populating data when there are 0 results
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
